### PR TITLE
Added Video Framerate to Fix 'prepare' crash

### DIFF
--- a/telecine/src/main/java/com/jakewharton/telecine/RecordingSession.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/RecordingSession.java
@@ -163,6 +163,7 @@ final class RecordingSession {
     recorder = new MediaRecorder();
     recorder.setVideoSource(SURFACE);
     recorder.setOutputFormat(MPEG_4);
+    recorder.setVideoFrameRate(30);
     recorder.setVideoEncoder(H264);
     recorder.setVideoSize(displayWidth, displayHeight);
     recorder.setVideoEncodingBitRate(8 * 1000 * 1000);


### PR DESCRIPTION
**Added Video Framerate to Fix 'prepare' crash - on HTC DNA running Android 5.0.2**

**Crash:**

java.lang.RuntimeException: Unable to prepare MediaRecorder.
                at com.jakewharton.telecine.RecordingSession.startRecording(RecordingSession.java:179)
                at com.jakewharton.telecine.RecordingSession.access$100(RecordingSession.java:47)
                at com.jakewharton.telecine.RecordingSession$1.onStart(RecordingSession.java:111)
                at com.jakewharton.telecine.OverlayView.startRecording(OverlayView.java:147)
                at com.jakewharton.telecine.OverlayView.access$300(OverlayView.java:31)
                at com.jakewharton.telecine.OverlayView$5$1$1.run(OverlayView.java:163)
                at android.view.ViewPropertyAnimator$AnimatorEventListener.onAnimationEnd(ViewPropertyAnimator.java:1121)
                at android.animation.ValueAnimator.endAnimation(ValueAnimator.java:1089)
                at android.animation.ValueAnimator$AnimationHandler.doAnimationFrame(ValueAnimator.java:666)
                at android.animation.ValueAnimator$AnimationHandler.run(ValueAnimator.java:682)
                at android.view.Choreographer$CallbackRecord.run(Choreographer.java:795)
                at android.view.Choreographer.doCallbacks(Choreographer.java:599)
                at android.view.Choreographer.doFrame(Choreographer.java:559)
                at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:781)
                at android.os.Handler.handleCallback(Handler.java:739)
                at android.os.Handler.dispatchMessage(Handler.java:95)
                at android.os.Looper.loop(Looper.java:135)
                at android.app.ActivityThread.main(ActivityThread.java:5466)
                at java.lang.reflect.Method.invoke(Method.java:-2)
                at java.lang.reflect.Method.invoke(Method.java:372)
                at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:938)
                at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:733)
        Caused by: java.io.IOException: prepare failed.
                at android.media.MediaRecorder._prepare(MediaRecorder.java:-2)
                at android.media.MediaRecorder.prepare(MediaRecorder.java:742)
                at com.jakewharton.telecine.RecordingSession.startRecording(RecordingSession.java:177)
                at com.jakewharton.telecine.RecordingSession.access$100(RecordingSession.java:47)
                at com.jakewharton.telecine.RecordingSession$1.onStart(RecordingSession.java:111)
                at com.jakewharton.telecine.OverlayView.startRecording(OverlayView.java:147)
                at com.jakewharton.telecine.OverlayView.access$300(OverlayView.java:31)
                at com.jakewharton.telecine.OverlayView$5$1$1.run(OverlayView.java:163)
                at android.view.ViewPropertyAnimator$AnimatorEventListener.onAnimationEnd(ViewPropertyAnimator.java:1121)
                at android.animation.ValueAnimator.endAnimation(ValueAnimator.java:1089)
                at android.animation.ValueAnimator$AnimationHandler.doAnimationFrame(ValueAnimator.java:666)
                at android.animation.ValueAnimator$AnimationHandler.run(ValueAnimator.java:682)
                at android.view.Choreographer$CallbackRecord.run(Choreographer.java:795)
                at android.view.Choreographer.doCallbacks(Choreographer.java:599)
                at android.view.Choreographer.doFrame(Choreographer.java:559)
                at android.view.Choreographer$FrameDisplayEventReceiver.run(Choreographer.java:781)
                at android.os.Handler.handleCallback(Handler.java:739)
                at android.os.Handler.dispatchMessage(Handler.java:95)
                at android.os.Looper.loop(Looper.java:135)
                at android.app.ActivityThread.main(ActivityThread.java:5466)
                at java.lang.reflect.Method.invoke(Method.java:-2)
                at java.lang.reflect.Method.invoke(Method.java:372)
                at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:938)
                at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:733)