### PR TITLE
Screen rotation leads to finish the Activity

### DIFF
--- a/telecine/src/main/java/com/jakewharton/telecine/TelecineActivity.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/TelecineActivity.java
@@ -130,8 +130,7 @@ public final class TelecineActivity extends Activity {
 
   @Override protected void onStop() {
     super.onStop();
-
-    if (hideFromRecentsPreference.get()) {
+    if (hideFromRecentsPreference.get() && !isChangingConfigurations()) {
       Timber.d("Removing task because hide from recents preference was enabled.");
       finishAndRemoveTask();
     }


### PR DESCRIPTION
If the `Hide from recent apps` switch is on, any configuration change will lead to finish the TelecineActivity.
The application should prevent this behavior and finish the Activity only if the user explicitely leaves the app.