### PR TITLE
Overlay is 24dp tall on Android M+.

### DIFF
--- a/telecine/src/main/java/com/jakewharton/telecine/OverlayView.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/OverlayView.java
@@ -5,6 +5,7 @@ import android.animation.AnimatorListenerAdapter;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.res.Resources;
+import android.os.Build;
 import android.support.annotation.NonNull;
 import android.view.Gravity;
 import android.view.View;
@@ -19,6 +20,7 @@ import butterknife.OnClick;
 import java.util.Locale;
 
 import static android.graphics.PixelFormat.TRANSLUCENT;
+import static android.os.Build.VERSION_CODES.LOLLIPOP_MR1;
 import static android.text.TextUtils.getLayoutDirectionFromLocale;
 import static android.view.ViewAnimationUtils.createCircularReveal;
 import static android.view.WindowManager.LayoutParams.FLAG_LAYOUT_INSET_DECOR;
@@ -42,6 +44,11 @@ final class OverlayView extends FrameLayout {
     Resources res = context.getResources();
     int width = res.getDimensionPixelSize(R.dimen.overlay_width);
     int height = res.getDimensionPixelSize(R.dimen.overlay_height);
+    // TODO Remove explicit "M" comparison when M is released.
+    if (Build.VERSION.SDK_INT > LOLLIPOP_MR1 || "M".equals(Build.VERSION.RELEASE)) {
+      height = res.getDimensionPixelSize(R.dimen.overlay_height_m);
+    }
+
     final WindowManager.LayoutParams params =
         new WindowManager.LayoutParams(width, height, TYPE_SYSTEM_ERROR, FLAG_NOT_FOCUSABLE
             | FLAG_NOT_TOUCH_MODAL

--- a/telecine/src/main/res/values/dimens.xml
+++ b/telecine/src/main/res/values/dimens.xml
@@ -2,4 +2,6 @@
   <dimen name="content_padding">16dp</dimen>
   <dimen name="overlay_width">96dp</dimen>
   <dimen name="overlay_height">25dp</dimen>
+  <!-- TODO move to values-23/ as overlay_height overload when M is released. -->
+  <dimen name="overlay_height_m">24dp</dimen>
 </resources>


### PR DESCRIPTION
Before:
![screenshot_20150619-001802](https://cloud.githubusercontent.com/assets/66577/8247161/9633cc62-1619-11e5-8875-caaaf153122d.png)
After:
![screenshot_20150619-002434](https://cloud.githubusercontent.com/assets/66577/8247164/9bffd64a-1619-11e5-83e1-24dbf0ddda6e.png)

Closes #57. 
