### PR TITLE
Removed Crashlytics from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,3 @@ reports
 
 # Mac OS
 .DS_Store
-
-# Crashlytics
-com_crashlytics_export_strings.xml
-crashlytics-build.properties


### PR DESCRIPTION
We moved to Bugsnag so Crashlytics ignores are not required anymore