### PR TITLE
Don't stop foreground notification explicitly.

### DIFF
--- a/telecine/src/main/java/com/jakewharton/telecine/TelecineService.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/TelecineService.java
@@ -68,8 +68,6 @@ public final class TelecineService extends Service {
       if (showTouchesProvider.get()) {
         Settings.System.putInt(contentResolver, SHOW_TOUCHES, 0);
       }
-
-      stopForeground(true /* remove notification */);
     }
 
     @Override public void onEnd() {


### PR DESCRIPTION
Let the service stopping automatically remove it. This keeps the foreground notification while the recording is being processed.