### PR TITLE
Crash eagerly when the Uri is missing.

### DIFF
--- a/telecine/src/main/java/com/jakewharton/telecine/RecordingSession.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/RecordingSession.java
@@ -288,6 +288,7 @@ final class RecordingSession {
     MediaScannerConnection.scanFile(context, new String[] { outputFile }, null,
         new MediaScannerConnection.OnScanCompletedListener() {
           @Override public void onScanCompleted(String path, final Uri uri) {
+            if (uri == null) throw new NullPointerException("uri == null");
             Timber.d("Media scanner completed.");
             mainThread.post(new Runnable() {
               @Override public void run() {


### PR DESCRIPTION
We already crash later on. This just moves it to the first availability of the resource.