### PR TITLE
Quick tile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,8 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-23.0.3
-    - android-23
+    - build-tools-24.0.0
+    - android-24
     - extra-android-m2repository
     - extra-google-m2repository
 

--- a/telecine/build.gradle
+++ b/telecine/build.gradle
@@ -22,8 +22,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.neenbedankt.android-apt'
 
 android {
-  compileSdkVersion 23
-  buildToolsVersion '23.0.3'
+  compileSdkVersion 24
+  buildToolsVersion '24.0.0'
 
   defaultConfig {
     applicationId 'com.jakewharton.telecine'
@@ -72,8 +72,8 @@ android {
 }
 
 dependencies {
-  compile 'com.android.support:support-annotations:23.4.0'
-  compile 'com.android.support:design:23.4.0'
+  compile 'com.android.support:support-annotations:24.0.0'
+  compile 'com.android.support:design:24.0.0'
   compile 'com.google.android.gms:play-services-analytics:9.0.2'
   compile 'com.jakewharton:butterknife:8.0.1'
   apt 'com.jakewharton:butterknife-compiler:8.0.1'

--- a/telecine/src/debug/res/values/strings.xml
+++ b/telecine/src/debug/res/values/strings.xml
@@ -4,4 +4,5 @@
   <string name="launcher_name" translatable="false">Telecine Debug</string>
 
   <string name="shortcut_name">Launch Debug</string>
+  <string name="tile_name">Launch Telecine Debug</string>
 </resources>

--- a/telecine/src/main/AndroidManifest.xml
+++ b/telecine/src/main/AndroidManifest.xml
@@ -47,6 +47,16 @@
         android:taskAffinity=""
         android:exported="true"
         />
+
+    <service
+        android:icon="@drawable/ic_videocam_white_24dp"
+        android:label="@string/tile_name"
+        android:name=".TelecineTileService"
+        android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+      <intent-filter>
+        <action android:name="android.service.quicksettings.action.QS_TILE"/>
+      </intent-filter>
+    </service>
   </application>
 
 </manifest>

--- a/telecine/src/main/java/com/jakewharton/telecine/TelecineTileService.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/TelecineTileService.java
@@ -1,0 +1,20 @@
+package com.jakewharton.telecine;
+
+import android.annotation.TargetApi;
+import android.content.Intent;
+import android.os.Build;
+import android.service.quicksettings.Tile;
+import android.service.quicksettings.TileService;
+
+@TargetApi(Build.VERSION_CODES.N) // Only created on N+
+public final class TelecineTileService extends TileService {
+  @Override public void onClick() {
+    startActivity(new Intent(this, TelecineShortcutLaunchActivity.class));
+  }
+
+  @Override public void onStartListening() {
+    Tile tile = getQsTile();
+    tile.setState(Tile.STATE_ACTIVE);
+    tile.updateTile();
+  }
+}

--- a/telecine/src/main/res/values/strings.xml
+++ b/telecine/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
   <string name="launcher_name" translatable="false">@string/app_name</string>
 
   <string name="shortcut_name">Launch</string>
+  <string name="tile_name">Launch Telecine</string>
   <string name="clear">Clear</string>
   <string name="record">Record</string>
   <string name="countdown_one">1…</string>


### PR DESCRIPTION
So can't merge this yet for obvious preview-related reasons. Also, as you're already aware, targeting SDK 23+ means storage and draw-over-apps permissions aren't granted automatically. Opening the PR now anyway so there's no duplicate efforts.

Closes #92.