### PR TITLE
Fixes #132, add static shortcuts

### DIFF
--- a/telecine/src/main/AndroidManifest.xml
+++ b/telecine/src/main/AndroidManifest.xml
@@ -27,6 +27,9 @@
         <category android:name="android.intent.category.LAUNCHER"/>
         <category android:name="android.intent.category.DEFAULT"/>
       </intent-filter>
+      <meta-data
+          android:name="android.app.shortcuts"
+          android:resource="@xml/shortcuts" />
     </activity>
 
     <service android:name=".TelecineService"/>

--- a/telecine/src/main/java/com/jakewharton/telecine/Analytics.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/Analytics.java
@@ -26,6 +26,8 @@ interface Analytics {
   String ACTION_QUICK_TILE_ADDED = "Quick Tile Added";
   String ACTION_QUICK_TILE_LAUNCHED = "Quick Tile Launched";
   String ACTION_QUICK_TILE_REMOVED = "Quick Tile Removed";
+  String ACTION_STATIC_SHORTCUT_RECORD = "Static Shortcut Record";
+  String ACTION_STATIC_SHORTCUT_OVERLAY = "Static Shortcut Overlay";
 
   String VARIABLE_RECORDING_LENGTH = "Recording Length";
 

--- a/telecine/src/main/java/com/jakewharton/telecine/RecordingSession.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/RecordingSession.java
@@ -194,6 +194,26 @@ final class RecordingSession {
         cameraWidth, cameraHeight, cameraFrameRate, sizePercentage);
   }
 
+  /**
+   * Perform a click on the start button to simulate the auto-recording
+   */
+  void triggerAutoRecording() {
+    if (overlayView == null) {
+      return;
+    }
+    // Most of the time, overlayView is not yet attached to the Window
+    if (overlayView.isAttachedToWindow()) {
+      overlayView.onStartClicked();
+    } else {
+      overlayView.post(new Runnable() {
+        @Override
+        public void run() {
+          triggerAutoRecording();
+        }
+      });
+    }
+  }
+
   private void startRecording() {
     Timber.d("Starting screen recording...");
 

--- a/telecine/src/main/java/com/jakewharton/telecine/TelecineService.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/TelecineService.java
@@ -98,6 +98,10 @@ public final class TelecineService extends Service {
             videoSizePercentageProvider);
     recordingSession.showOverlay();
 
+    if (data.getBooleanExtra(TelecineShortcutLaunchActivity.EXTRA_AUTO_RECORDING, false)) {
+      Timber.d("Auto-recording requested!");
+      recordingSession.triggerAutoRecording();
+    }
     return START_NOT_STICKY;
   }
 

--- a/telecine/src/main/java/com/jakewharton/telecine/TelecineShortcutLaunchActivity.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/TelecineShortcutLaunchActivity.java
@@ -9,6 +9,7 @@ import javax.inject.Inject;
 
 public final class TelecineShortcutLaunchActivity extends Activity {
   private static final String KEY_ACTION = "launch-action";
+  static final String EXTRA_AUTO_RECORDING = "auto-recording";
 
   static Intent createQuickTileIntent(Context context) {
     Intent intent = new Intent(context, TelecineShortcutLaunchActivity.class);
@@ -36,6 +37,10 @@ public final class TelecineShortcutLaunchActivity extends Activity {
   }
 
   @Override protected void onActivityResult(int requestCode, int resultCode, Intent data) {
+    // inject the auto-recording extra from the original intent to the result data
+    if (getIntent().getBooleanExtra(EXTRA_AUTO_RECORDING, false) && data != null) {
+      data.putExtra(EXTRA_AUTO_RECORDING, true);
+    }
     if (!CaptureHelper.handleActivityResult(this, requestCode, resultCode, data, analytics)) {
       super.onActivityResult(requestCode, resultCode, data);
     }

--- a/telecine/src/main/res/drawable/ic_shortcut_overlay.xml
+++ b/telecine/src/main/res/drawable/ic_shortcut_overlay.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportHeight="49.333336"
+    android:viewportWidth="49.333336">
+    <path
+        android:fillAlpha="1"
+        android:fillColor="#f5f5f5"
+        android:pathData="M24.67,24.67m-22,0a22,22 0,1 1,44 0a22,22 0,1 1,-44 0" />
+    <path
+        android:fillAlpha="1"
+        android:fillColor="#e73c35"
+        android:pathData="m31.42,17.92 l-13.5,0c-0.82,0 -1.5,0.68 -1.5,1.5l0,10.5c0,0.82 0.68,1.5 1.5,1.5l13.5,0c0.82,0 1.5,-0.68 1.5,-1.5l0,-10.5c0,-0.82 -0.68,-1.5 -1.5,-1.5zM31.42,29.92 L17.92,29.92 17.92,19.42 25.42,19.42 25.42,22.42 31.42,22.42 31.42,29.92z" />
+</vector>

--- a/telecine/src/main/res/drawable/ic_shortcut_record.xml
+++ b/telecine/src/main/res/drawable/ic_shortcut_record.xml
@@ -1,0 +1,14 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="48dp"
+    android:height="48dp"
+    android:viewportHeight="49.333336"
+    android:viewportWidth="49.333336">
+    <path
+        android:fillAlpha="1"
+        android:fillColor="#f5f5f5"
+        android:pathData="M24.67,24.67m-22,0a22,22 0,1 1,44 0a22,22 0,1 1,-44 0" />
+    <path
+        android:fillAlpha="1"
+        android:fillColor="#e73c35"
+        android:pathData="m29.67,23.17 l0,-3.5c0,-0.55 -0.45,-1 -1,-1l-12,0c-0.55,0 -1,0.45 -1,1l0,10c0,0.55 0.45,1 1,1l12,0c0.55,0 1,-0.45 1,-1l0,-3.5 4,4 0,-11 -4,4z" />
+</vector>

--- a/telecine/src/main/res/values/strings.xml
+++ b/telecine/src/main/res/values/strings.xml
@@ -24,6 +24,12 @@
   <string name="notification_recording_subtitle">Touch the clock area to stop recording.</string>
   <string name="recording_notification">Recording Notification</string>
   <string name="show_touches">Show Touches</string>
+  <string name="static_shortcut_record_short_label">Record</string>
+  <string name="static_shortcut_record_long_label">Start recording</string>
+  <string name="static_shortcut_record_disabled_message">@string/static_shortcut_record_short_label</string>
+  <string name="static_shortcut_overlay_short_label">Overlay</string>
+  <string name="static_shortcut_overlay_long_label">Show overlay</string>
+  <string name="static_shortcut_overlay_disabled_message">@string/static_shortcut_overlay_short_label</string>
 
   <array name="countdown">
     <item>@string/countdown_three</item>

--- a/telecine/src/main/res/xml/shortcuts.xml
+++ b/telecine/src/main/res/xml/shortcuts.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts xmlns:android="http://schemas.android.com/apk/res/android">
+    <shortcut
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_overlay"
+        android:shortcutDisabledMessage="@string/static_shortcut_overlay_disabled_message"
+        android:shortcutId="overlay"
+        android:shortcutLongLabel="@string/static_shortcut_overlay_long_label"
+        android:shortcutShortLabel="@string/static_shortcut_overlay_short_label">
+        <intent
+            android:action="com.jakewharton.telecine.STATIC_SHORTCUT_OVERLAY"
+            android:targetClass="com.jakewharton.telecine.TelecineShortcutLaunchActivity"
+            android:targetPackage="com.jakewharton.telecine">
+            <extra
+                android:name="launch-action"
+                android:value="Static Shortcut Overlay" />
+        </intent>
+        <categories android:name="android.shortcut.conversation" />
+    </shortcut>
+    <shortcut
+        android:enabled="true"
+        android:icon="@drawable/ic_shortcut_record"
+        android:shortcutDisabledMessage="@string/static_shortcut_record_disabled_message"
+        android:shortcutId="record"
+        android:shortcutLongLabel="@string/static_shortcut_record_long_label"
+        android:shortcutShortLabel="@string/static_shortcut_record_short_label">
+        <intent
+            android:action="com.jakewharton.telecine.STATIC_SHORTCUT_RECORD"
+            android:targetClass="com.jakewharton.telecine.TelecineShortcutLaunchActivity"
+            android:targetPackage="com.jakewharton.telecine">
+            <extra
+                android:name="launch-action"
+                android:value="Static Shortcut Record" />
+            <extra
+                android:name="auto-recording"
+                android:value="true" />
+        </intent>
+        <categories android:name="android.shortcut.conversation" />
+    </shortcut>
+</shortcuts>


### PR DESCRIPTION
Enable two static shortcuts on API 25: record and overlay.

There are two new Analytics events:
- Static Shortcut Record
- Static Shortcut Overlay

The `record` shortcut is using an extra parameter injected in the Intent result (from the ScreenCaptureIntent API) retrieved at the TelecineService to fake the click on the start button. (It might also be used from the QuickTile I suppose) 

Since I'm no expert on SVG, I created two resources on Inkscape and import them with AndroidStudio (hence the floating point values...). And I tried to make something similar to other shortcuts (maps, chrome, etc.)

Unfortunately, the manifest merger isn't yet compatible with xml resources other than the AndroidManifest.
Therefore, if you want to test it on a debug build, you must add the `.debug` in both `android:targetPackage` of the `xml/shortcuts.xml` file.

![screenshot_1480085487](https://cloud.githubusercontent.com/assets/1921278/20628585/133be70c-b327-11e6-87ca-deac42f8188d.png)
