### PR TITLE
Switch to Firebase Analytics, closes #123

### DIFF
--- a/telecine/build.gradle
+++ b/telecine/build.gradle
@@ -7,6 +7,7 @@ def versionBuild = 0 // bump for dogfood builds, public betas, etc.
 buildscript {
   dependencies {
     classpath 'com.android.tools.build:gradle:2.2.2'
+    classpath 'com.google.gms:google-services:3.0.0'
   }
 }
 
@@ -83,7 +84,10 @@ dependencies {
   compile 'com.jakewharton.timber:timber:4.3.1'
   compile 'com.bugsnag:bugsnag-android:3.7.0'
   compile 'com.google.dagger:dagger:2.8'
+  compile 'com.google.firebase:firebase-core:10.0.0'
   annotationProcessor 'com.google.dagger:dagger-compiler:2.8'
   testCompile 'junit:junit:4.12'
   testCompile 'com.google.truth:truth:0.30'
 }
+
+apply plugin: 'com.google.gms.google-services'

--- a/telecine/src/debug/google-services.json
+++ b/telecine/src/debug/google-services.json
@@ -1,0 +1,25 @@
+{
+  "project_info": {
+    "project_number": ""
+  },
+  "client": [
+    {
+      "client_info": {
+        "android_client_info": {
+          "package_name": "com.jakewharton.telecine.debug"
+        }
+      },
+      "api_key": [
+        {
+          "current_key": ""
+        }
+      ],
+      "services": {
+        "analytics_service": {
+          "status": 1
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/telecine/src/main/java/com/jakewharton/telecine/Analytics.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/Analytics.java
@@ -1,46 +1,52 @@
 package com.jakewharton.telecine;
 
-import com.google.android.gms.analytics.Tracker;
-import java.util.Map;
+import android.os.Bundle;
+import com.google.firebase.analytics.FirebaseAnalytics;
 
+// Event name should be 1 to 32 alphanumeric according to FirebaseAnalytics
 interface Analytics {
-  String CATEGORY_SETTINGS = "Settings";
-  String CATEGORY_RECORDING = "Recording";
-  String CATEGORY_SHORTCUT = "Shortcut";
-  String CATEGORY_QUICK_TILE = "Quick Tile";
+  String EVENT_CAPTURE_INTENT_LAUNCH = "settings_overlay_launch";
+  String EVENT_CAPTURE_INTENT_RESULT = "settings_overlay_result_";
+  String EVENT_CHANGE_VIDEO_SIZE = "settings_change_video_size_";
+  String EVENT_CHANGE_SHOW_COUNTDOWN_YES = "settings_show_countdown_yes";
+  String EVENT_CHANGE_SHOW_COUNTDOWN_NO = "settings_show_countdown_no";
+  String EVENT_CHANGE_HIDE_RECENTS_YES = "settings_hide_in_recents_yes";
+  String EVENT_CHANGE_HIDE_RECENTS_NO = "settings_hide_in_recents_no";
+  String EVENT_CHANGE_RECORDING_NOTIFICATION_YES = "settings_record_notification_yes";
+  String EVENT_CHANGE_RECORDING_NOTIFICATION_NO = "settings_record_notification_no";
+  String EVENT_CHANGE_SHOW_TOUCHES_YES = "settings_show_touches_yes";
+  String EVENT_CHANGE_SHOW_TOUCHES_NO = "settings_show_touches_no";
+  String EVENT_OVERLAY_SHOW = "recording_overlay_show";
+  String EVENT_OVERLAY_HIDE = "recording_overlay_hide";
+  String EVENT_OVERLAY_CANCEL = "recording_overlay_cancel";
+  String EVENT_RECORDING_START = "recording_recording_start";
+  String EVENT_RECORDING_STOP = "recording_recording_stop";
+  String EVENT_RECORDING_LENGTH = "recording_length";
+  String EVENT_SHORTCUT_ADDED = "shortcut_added";
+  String EVENT_SHORTCUT_LAUNCHED = "shortcut_launched";
+  String EVENT_QUICK_TILE_ADDED = "quick_tile_added";
+  String EVENT_QUICK_TILE_LAUNCHED = "quick_tile_launched";
+  String EVENT_QUICK_TILE_REMOVED = "quick_tile_removed";
+  String EVENT_STATIC_SHORTCUT_RECORD = "static_shortcut_record";
+  String EVENT_STATIC_SHORTCUT_OVERLAY = "static_shortcut_overlay";
 
-  String ACTION_CAPTURE_INTENT_LAUNCH = "Launch Overlay Launch";
-  String ACTION_CAPTURE_INTENT_RESULT = "Launch Overlay Result";
-  String ACTION_CHANGE_VIDEO_SIZE = "Change Video Size";
-  String ACTION_CHANGE_SHOW_COUNTDOWN = "Show Countdown";
-  String ACTION_CHANGE_HIDE_RECENTS = "Hide In Recents";
-  String ACTION_CHANGE_RECORDING_NOTIFICATION = "Recording Notification";
-  String ACTION_CHANGE_SHOW_TOUCHES = "Show Touches";
-  String ACTION_OVERLAY_SHOW = "Overlay Show";
-  String ACTION_OVERLAY_HIDE = "Overlay Hide";
-  String ACTION_OVERLAY_CANCEL = "Overlay Cancel";
-  String ACTION_RECORDING_START = "Recording Start";
-  String ACTION_RECORDING_STOP = "Recording Stop";
-  String ACTION_SHORTCUT_ADDED = "Shortcut Added";
-  String ACTION_SHORTCUT_LAUNCHED = "Shortcut Launched";
-  String ACTION_QUICK_TILE_ADDED = "Quick Tile Added";
-  String ACTION_QUICK_TILE_LAUNCHED = "Quick Tile Launched";
-  String ACTION_QUICK_TILE_REMOVED = "Quick Tile Removed";
+  void send(String name);
+  void send(String name, long value);
 
-  String VARIABLE_RECORDING_LENGTH = "Recording Length";
+  class FirebaseAnalyticsImpl implements Analytics {
+    private final com.google.firebase.analytics.FirebaseAnalytics analytics;
 
-  /** @see {@link Tracker#send(Map)} for usage. */
-  void send(Map<String, String> params);
-
-  class GoogleAnalytics implements Analytics {
-    private final Tracker tracker;
-
-    public GoogleAnalytics(Tracker tracker) {
-      this.tracker = tracker;
+    FirebaseAnalyticsImpl(com.google.firebase.analytics.FirebaseAnalytics analytics) {
+      this.analytics = analytics;
     }
 
-    @Override public void send(Map<String, String> params) {
-      tracker.send(params);
+    @Override public void send(String name) {
+      analytics.logEvent(name, null);
+    }
+    @Override public void send(String name, long value) {
+      Bundle bundle = new Bundle(1);
+      bundle.putLong(FirebaseAnalytics.Param.VALUE, value);
+      analytics.logEvent(name, bundle);
     }
   }
 }

--- a/telecine/src/main/java/com/jakewharton/telecine/CaptureHelper.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/CaptureHelper.java
@@ -3,7 +3,6 @@ package com.jakewharton.telecine;
 import android.app.Activity;
 import android.content.Intent;
 import android.media.projection.MediaProjectionManager;
-import com.google.android.gms.analytics.HitBuilders;
 import timber.log.Timber;
 
 import static android.content.Context.MEDIA_PROJECTION_SERVICE;
@@ -21,10 +20,7 @@ final class CaptureHelper {
     Intent intent = manager.createScreenCaptureIntent();
     activity.startActivityForResult(intent, CREATE_SCREEN_CAPTURE);
 
-    analytics.send(new HitBuilders.EventBuilder() //
-        .setCategory(Analytics.CATEGORY_SETTINGS)
-        .setAction(Analytics.ACTION_CAPTURE_INTENT_LAUNCH)
-        .build());
+    analytics.send(Analytics.EVENT_CAPTURE_INTENT_LAUNCH);
   }
 
   static boolean handleActivityResult(Activity activity, int requestCode, int resultCode,
@@ -40,11 +36,7 @@ final class CaptureHelper {
       Timber.d("Failed to acquire permission to screen capture.");
     }
 
-    analytics.send(new HitBuilders.EventBuilder() //
-        .setCategory(Analytics.CATEGORY_SETTINGS)
-        .setAction(Analytics.ACTION_CAPTURE_INTENT_RESULT)
-        .setValue(resultCode)
-        .build());
+    analytics.send(Analytics.EVENT_CAPTURE_INTENT_RESULT + resultCode);
 
     return true;
   }

--- a/telecine/src/main/java/com/jakewharton/telecine/RecordingSession.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/RecordingSession.java
@@ -25,7 +25,6 @@ import android.util.DisplayMetrics;
 import android.view.Surface;
 import android.view.WindowManager;
 import android.widget.Toast;
-import com.google.android.gms.analytics.HitBuilders;
 import java.io.File;
 import java.io.IOException;
 import java.text.DateFormat;
@@ -138,10 +137,7 @@ final class RecordingSession {
     overlayView = OverlayView.create(context, overlayListener, showCountDown.get());
     windowManager.addView(overlayView, OverlayView.createLayoutParams(context));
 
-    analytics.send(new HitBuilders.EventBuilder() //
-        .setCategory(Analytics.CATEGORY_RECORDING)
-        .setAction(Analytics.ACTION_OVERLAY_SHOW)
-        .build());
+    analytics.send(Analytics.EVENT_OVERLAY_SHOW);
   }
 
   private void hideOverlay() {
@@ -150,10 +146,7 @@ final class RecordingSession {
       windowManager.removeView(overlayView);
       overlayView = null;
 
-      analytics.send(new HitBuilders.EventBuilder() //
-          .setCategory(Analytics.CATEGORY_RECORDING)
-          .setAction(Analytics.ACTION_OVERLAY_HIDE)
-          .build());
+      analytics.send(Analytics.EVENT_OVERLAY_HIDE);
     }
   }
 
@@ -161,10 +154,7 @@ final class RecordingSession {
     hideOverlay();
     listener.onEnd();
 
-    analytics.send(new HitBuilders.EventBuilder() //
-        .setCategory(Analytics.CATEGORY_RECORDING)
-        .setAction(Analytics.ACTION_OVERLAY_CANCEL)
-        .build());
+    analytics.send(Analytics.EVENT_OVERLAY_CANCEL);
   }
 
   private RecordingInfo getRecordingInfo() {
@@ -241,10 +231,7 @@ final class RecordingSession {
 
     Timber.d("Screen recording started.");
 
-    analytics.send(new HitBuilders.EventBuilder() //
-        .setCategory(Analytics.CATEGORY_RECORDING)
-        .setAction(Analytics.ACTION_RECORDING_START)
-        .build());
+    analytics.send(Analytics.EVENT_RECORDING_START);
   }
 
   private void stopRecording() {
@@ -282,15 +269,8 @@ final class RecordingSession {
     recorder.release();
     display.release();
 
-    analytics.send(new HitBuilders.EventBuilder() //
-        .setCategory(Analytics.CATEGORY_RECORDING)
-        .setAction(Analytics.ACTION_RECORDING_STOP)
-        .build());
-    analytics.send(new HitBuilders.TimingBuilder() //
-        .setCategory(Analytics.CATEGORY_RECORDING)
-        .setValue(TimeUnit.NANOSECONDS.toMillis(recordingStopNanos - recordingStartNanos))
-        .setVariable(Analytics.VARIABLE_RECORDING_LENGTH)
-        .build());
+    analytics.send(Analytics.EVENT_RECORDING_STOP);
+    analytics.send(Analytics.EVENT_RECORDING_LENGTH, TimeUnit.NANOSECONDS.toMillis(recordingStopNanos - recordingStartNanos));
 
     Timber.d("Screen recording stopped. Notifying media scanner of new video.");
 

--- a/telecine/src/main/java/com/jakewharton/telecine/TelecineActivity.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/TelecineActivity.java
@@ -19,7 +19,6 @@ import butterknife.ButterKnife;
 import butterknife.OnCheckedChanged;
 import butterknife.OnClick;
 import butterknife.OnItemSelected;
-import com.google.android.gms.analytics.HitBuilders;
 import javax.inject.Inject;
 import timber.log.Timber;
 
@@ -101,11 +100,7 @@ public final class TelecineActivity extends AppCompatActivity {
       Timber.d("Video size percentage changing to %s%%", newValue);
       videoSizePreference.set(newValue);
 
-      analytics.send(new HitBuilders.EventBuilder() //
-          .setCategory(Analytics.CATEGORY_SETTINGS)
-          .setAction(Analytics.ACTION_CHANGE_VIDEO_SIZE)
-          .setValue(newValue)
-          .build());
+      analytics.send(Analytics.EVENT_CHANGE_VIDEO_SIZE + newValue);
     }
   }
 
@@ -116,11 +111,7 @@ public final class TelecineActivity extends AppCompatActivity {
       Timber.d("Hide show countdown changing to %s", newValue);
       showCountdownPreference.set(newValue);
 
-      analytics.send(new HitBuilders.EventBuilder() //
-          .setCategory(Analytics.CATEGORY_SETTINGS)
-          .setAction(Analytics.ACTION_CHANGE_SHOW_COUNTDOWN)
-          .setValue(newValue ? 1 : 0)
-          .build());
+      analytics.send(newValue ? Analytics.EVENT_CHANGE_SHOW_COUNTDOWN_YES : Analytics.EVENT_CHANGE_SHOW_COUNTDOWN_NO);
     }
   }
 
@@ -131,11 +122,7 @@ public final class TelecineActivity extends AppCompatActivity {
       Timber.d("Hide from recents preference changing to %s", newValue);
       hideFromRecentsPreference.set(newValue);
 
-      analytics.send(new HitBuilders.EventBuilder() //
-          .setCategory(Analytics.CATEGORY_SETTINGS)
-          .setAction(Analytics.ACTION_CHANGE_HIDE_RECENTS)
-          .setValue(newValue ? 1 : 0)
-          .build());
+      analytics.send(newValue ? Analytics.EVENT_CHANGE_HIDE_RECENTS_YES : Analytics.EVENT_CHANGE_HIDE_RECENTS_NO);
     }
   }
 
@@ -146,11 +133,7 @@ public final class TelecineActivity extends AppCompatActivity {
       Timber.d("Recording notification preference changing to %s", newValue);
       recordingNotificationPreference.set(newValue);
 
-      analytics.send(new HitBuilders.EventBuilder() //
-          .setCategory(Analytics.CATEGORY_SETTINGS)
-          .setAction(Analytics.ACTION_CHANGE_RECORDING_NOTIFICATION)
-          .setValue(newValue ? 1 : 0)
-          .build());
+      analytics.send(newValue ? Analytics.EVENT_CHANGE_RECORDING_NOTIFICATION_YES : Analytics.EVENT_CHANGE_RECORDING_NOTIFICATION_NO);
     }
   }
 
@@ -161,11 +144,7 @@ public final class TelecineActivity extends AppCompatActivity {
       Timber.d("Show touches preference changing to %s", newValue);
       showTouchesPreference.set(newValue);
 
-      analytics.send(new HitBuilders.EventBuilder() //
-          .setCategory(Analytics.CATEGORY_SETTINGS)
-          .setAction(Analytics.ACTION_CHANGE_SHOW_TOUCHES)
-          .setValue(newValue ? 1 : 0)
-          .build());
+      analytics.send(newValue ? Analytics.EVENT_CHANGE_SHOW_TOUCHES_YES : Analytics.EVENT_CHANGE_SHOW_TOUCHES_NO);
     }
   }
 

--- a/telecine/src/main/java/com/jakewharton/telecine/TelecineModule.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/TelecineModule.java
@@ -2,14 +2,12 @@ package com.jakewharton.telecine;
 
 import android.content.ContentResolver;
 import android.content.SharedPreferences;
-import com.google.android.gms.analytics.GoogleAnalytics;
-import com.google.android.gms.analytics.Tracker;
+import com.google.firebase.analytics.FirebaseAnalytics;
 import dagger.Module;
 import dagger.Provides;
 import timber.log.Timber;
 
 import javax.inject.Singleton;
-import java.util.Map;
 
 import static android.content.Context.MODE_PRIVATE;
 
@@ -31,16 +29,17 @@ final class TelecineModule {
   @Provides @Singleton Analytics provideAnalytics() {
     if (BuildConfig.DEBUG) {
       return new Analytics() {
-        @Override public void send(Map<String, String> params) {
-          Timber.tag("Analytics").d(String.valueOf(params));
+        @Override
+        public void send(String name) {
+          Timber.tag("Analytics").d(name);
+        }
+        @Override
+        public void send(String name, long value) {
+          Timber.tag("Analytics").d(name + "=" + value);
         }
       };
     }
-
-    GoogleAnalytics googleAnalytics = GoogleAnalytics.getInstance(app);
-    Tracker tracker = googleAnalytics.newTracker(BuildConfig.ANALYTICS_KEY);
-    tracker.setSessionTimeout(300); // ms? s? better be s.
-    return new Analytics.GoogleAnalytics(tracker);
+    return new Analytics.FirebaseAnalyticsImpl(FirebaseAnalytics.getInstance(app));
   }
 
   @Provides @Singleton ContentResolver provideContentResolver() {

--- a/telecine/src/main/java/com/jakewharton/telecine/TelecineShortcutConfigureActivity.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/TelecineShortcutConfigureActivity.java
@@ -3,7 +3,6 @@ package com.jakewharton.telecine;
 import android.app.Activity;
 import android.content.Intent;
 import android.os.Bundle;
-import com.google.android.gms.analytics.HitBuilders;
 import javax.inject.Inject;
 
 import static android.content.Intent.ShortcutIconResource;
@@ -15,10 +14,7 @@ public final class TelecineShortcutConfigureActivity extends Activity {
     super.onCreate(savedInstanceState);
 
     ((TelecineApplication) getApplication()).injector().inject(this);
-    analytics.send(new HitBuilders.EventBuilder() //
-        .setCategory(Analytics.CATEGORY_SHORTCUT) //
-        .setAction(Analytics.ACTION_SHORTCUT_ADDED) //
-        .build());
+    analytics.send(Analytics.EVENT_SHORTCUT_ADDED);
 
     Intent launchIntent = new Intent(this, TelecineShortcutLaunchActivity.class);
     ShortcutIconResource icon = ShortcutIconResource.fromContext(this, R.drawable.ic_launcher);

--- a/telecine/src/main/java/com/jakewharton/telecine/TelecineShortcutLaunchActivity.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/TelecineShortcutLaunchActivity.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import com.google.android.gms.analytics.HitBuilders;
 import javax.inject.Inject;
 
 public final class TelecineShortcutLaunchActivity extends Activity {
@@ -12,7 +11,7 @@ public final class TelecineShortcutLaunchActivity extends Activity {
 
   static Intent createQuickTileIntent(Context context) {
     Intent intent = new Intent(context, TelecineShortcutLaunchActivity.class);
-    intent.putExtra(KEY_ACTION, Analytics.ACTION_QUICK_TILE_LAUNCHED);
+    intent.putExtra(KEY_ACTION, Analytics.EVENT_QUICK_TILE_LAUNCHED);
     return intent;
   }
 
@@ -24,13 +23,10 @@ public final class TelecineShortcutLaunchActivity extends Activity {
 
     String launchAction = getIntent().getStringExtra(KEY_ACTION);
     if (launchAction == null) {
-      launchAction = Analytics.ACTION_SHORTCUT_LAUNCHED;
+      launchAction = Analytics.EVENT_SHORTCUT_LAUNCHED;
     }
 
-    analytics.send(new HitBuilders.EventBuilder() //
-        .setCategory(Analytics.CATEGORY_SHORTCUT)
-        .setAction(launchAction)
-        .build());
+    analytics.send(launchAction);
 
     CaptureHelper.fireScreenCaptureIntent(this, analytics);
   }

--- a/telecine/src/main/java/com/jakewharton/telecine/TelecineTileService.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/TelecineTileService.java
@@ -4,7 +4,6 @@ import android.annotation.TargetApi;
 import android.os.Build;
 import android.service.quicksettings.Tile;
 import android.service.quicksettings.TileService;
-import com.google.android.gms.analytics.HitBuilders;
 import javax.inject.Inject;
 import timber.log.Timber;
 
@@ -34,17 +33,11 @@ public final class TelecineTileService extends TileService {
 
   @Override public void onTileAdded() {
     Timber.i("Quick tile added");
-    analytics.send(new HitBuilders.EventBuilder() //
-        .setCategory(Analytics.CATEGORY_QUICK_TILE)
-        .setAction(Analytics.ACTION_QUICK_TILE_ADDED)
-        .build());
+    analytics.send(Analytics.EVENT_QUICK_TILE_ADDED);
   }
 
   @Override public void onTileRemoved() {
     Timber.i("Quick tile removed");
-    analytics.send(new HitBuilders.EventBuilder() //
-        .setCategory(Analytics.CATEGORY_QUICK_TILE)
-        .setAction(Analytics.ACTION_QUICK_TILE_ADDED)
-        .build());
+    analytics.send(Analytics.EVENT_QUICK_TILE_REMOVED);
   }
 }


### PR DESCRIPTION
I had to change the `Analytics` interface since firebase can no longer support such categories.
Therefore **this change is not backward compatible** with previous analytics.

Notes:
- I've splitted analytics events accordingly: with a category prefix and `*_yes` `*_no` for boolean
- `EVENT_RECORDING_LENGTH` values will be automatically accumulated as explained [here](https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Param.html#VALUE)
- Another change will be required if #135 is merged
- A new `google-services.json` is required for release builds