### PR TITLE
Continues #139 Enable two static shortcuts: record and overlay.

### DIFF
--- a/telecine/src/debug/res/xml/shortcuts.xml
+++ b/telecine/src/debug/res/xml/shortcuts.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shortcuts
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:targetApi="n_mr1"
+    >
+  <shortcut
+      android:enabled="true"
+      android:icon="@drawable/ic_shortcut_overlay_48dp"
+      android:shortcutDisabledMessage="@string/launch"
+      android:shortcutId="overlay"
+      android:shortcutLongLabel="@string/launch_telecine"
+      android:shortcutShortLabel="@string/launch"
+      >
+    <intent
+        android:action="com.jakewharton.telecine.STATIC_SHORTCUT_OVERLAY"
+        android:targetClass="com.jakewharton.telecine.TelecineShortcutLaunchActivity"
+        android:targetPackage="com.jakewharton.telecine.debug"
+        >
+      <extra
+          android:name="launch-action"
+          android:value="Static Shortcut Overlay"
+          />
+    </intent>
+    <categories android:name="android.shortcut.conversation"/>
+  </shortcut>
+  <shortcut
+      android:enabled="true"
+      android:icon="@drawable/ic_shortcut_record_48dp"
+      android:shortcutDisabledMessage="@string/record"
+      android:shortcutId="record"
+      android:shortcutLongLabel="@string/start_recording"
+      android:shortcutShortLabel="@string/record"
+      >
+    <intent
+        android:action="com.jakewharton.telecine.STATIC_SHORTCUT_RECORD"
+        android:targetClass="com.jakewharton.telecine.TelecineShortcutLaunchActivity"
+        android:targetPackage="com.jakewharton.telecine.debug"
+        >
+      <extra
+          android:name="launch-action"
+          android:value="Static Shortcut Record"
+          />
+      <extra
+          android:name="auto-recording"
+          android:value="true"
+          />
+    </intent>
+    <categories android:name="android.shortcut.conversation"/>
+  </shortcut>
+</shortcuts>

--- a/telecine/src/main/res/xml/shortcuts.xml
+++ b/telecine/src/main/res/xml/shortcuts.xml
@@ -6,7 +6,7 @@
     >
   <shortcut
       android:enabled="true"
-      android:icon="@drawable/ic_shortcut_overlay"
+      android:icon="@drawable/ic_shortcut_overlay_48dp"
       android:shortcutDisabledMessage="@string/launch"
       android:shortcutId="overlay"
       android:shortcutLongLabel="@string/launch_telecine"
@@ -26,7 +26,7 @@
   </shortcut>
   <shortcut
       android:enabled="true"
-      android:icon="@drawable/ic_shortcut_record"
+      android:icon="@drawable/ic_shortcut_record_48dp"
       android:shortcutDisabledMessage="@string/record"
       android:shortcutId="record"
       android:shortcutLongLabel="@string/start_recording"


### PR DESCRIPTION
Since I don't know how to directly update #139 with these changes, GitHub hinted me to create a new pull request.