### PR TITLE
Add Demo Mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ android:
   components:
     - tools
     - platform-tools
-    - build-tools-25.0.1
+    - build-tools-25.0.2
     - android-25
     - extra-android-m2repository
     - extra-google-m2repository

--- a/telecine/build.gradle
+++ b/telecine/build.gradle
@@ -6,7 +6,7 @@ def versionBuild = 0 // bump for dogfood builds, public betas, etc.
 
 buildscript {
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.2.2'
+    classpath 'com.android.tools.build:gradle:2.2.3'
   }
 }
 
@@ -21,7 +21,7 @@ apply plugin: 'com.android.application'
 
 android {
   compileSdkVersion 25
-  buildToolsVersion '25.0.1'
+  buildToolsVersion '25.0.2'
 
   defaultConfig {
     applicationId 'com.jakewharton.telecine'
@@ -75,9 +75,10 @@ android {
 }
 
 dependencies {
-  compile 'com.android.support:support-annotations:25.0.1'
-  compile 'com.android.support:design:25.0.1'
-  compile 'com.google.android.gms:play-services-analytics:10.0.0'
+  compile 'com.android.support:support-annotations:25.1.0'
+  compile 'com.android.support:design:25.1.0'
+  compile 'com.google.android.gms:play-services-analytics:10.0.1'
+  compile 'com.nightlynexus.demomode:demomode:0.1.1'
   compile 'com.jakewharton:butterknife:8.4.0'
   annotationProcessor 'com.jakewharton:butterknife-compiler:8.4.0'
   compile 'com.jakewharton.timber:timber:4.3.1'

--- a/telecine/src/main/AndroidManifest.xml
+++ b/telecine/src/main/AndroidManifest.xml
@@ -11,6 +11,10 @@
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
   <uses-permission android:name="android.permission.WRITE_SETTINGS" />
   <uses-permission android:name="android.permission.WAKE_LOCK" tools:node="remove" />
+  <uses-permission android:name="android.permission.WRITE_SECURE_SETTINGS"
+      tools:ignore="ProtectedPermissions"/>
+  <uses-permission android:name="android.permission.DUMP"
+      tools:ignore="ProtectedPermissions"/>
 
   <application
       android:allowBackup="true"

--- a/telecine/src/main/java/com/jakewharton/telecine/Analytics.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/Analytics.java
@@ -16,6 +16,7 @@ interface Analytics {
   String ACTION_CHANGE_HIDE_RECENTS = "Hide In Recents";
   String ACTION_CHANGE_RECORDING_NOTIFICATION = "Recording Notification";
   String ACTION_CHANGE_SHOW_TOUCHES = "Show Touches";
+  String ACTION_CHANGE_USE_DEMO_MODE = "Use Demo Mode";
   String ACTION_OVERLAY_SHOW = "Overlay Show";
   String ACTION_OVERLAY_HIDE = "Overlay Hide";
   String ACTION_OVERLAY_CANCEL = "Overlay Cancel";

--- a/telecine/src/main/java/com/jakewharton/telecine/DemoModeHelper.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/DemoModeHelper.java
@@ -1,0 +1,96 @@
+package com.jakewharton.telecine;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.os.AsyncTask;
+import android.widget.Toast;
+import com.nightlynexus.demomode.DemoMode;
+import com.nightlynexus.demomode.DemoModeInitializer;
+
+import static android.os.Build.VERSION.SDK_INT;
+import static android.os.Build.VERSION_CODES.M;
+import static android.widget.Toast.LENGTH_SHORT;
+import static com.nightlynexus.demomode.DemoModeInitializer.DemoModeSetting.ENABLED;
+import static com.nightlynexus.demomode.DemoModeInitializer.GrantPermissionResult.FAILURE;
+import static com.nightlynexus.demomode.DemoModeInitializer.GrantPermissionResult.SUCCESS;
+
+final class DemoModeHelper {
+  private static final int REQUEST_CODE_ENABLE_DEMO_MODE = 5309;
+
+  private DemoModeHelper() {
+    throw new AssertionError("No instances.");
+  }
+
+  private enum DemoModeAvailability {
+    AVAILABLE, UNAVAILABLE, NEEDS_ROOT_ACCESS, NEEDS_DEMO_MODE_SETTING
+  }
+
+  interface ShowDemoModeSetting {
+    void show();
+
+    void hide();
+  }
+
+  static void showDemoModeSetting(final Activity activity, final ShowDemoModeSetting callback) {
+    if (SDK_INT < M) {
+      callback.hide();
+      return;
+    }
+    showDemoModeSetting23(activity, callback);
+  }
+
+  @TargetApi(M) private static void showDemoModeSetting23(final Activity activity,
+      final ShowDemoModeSetting callback) {
+    final DemoModeInitializer demoModeInitializer = DemoMode.initializer(activity);
+    new AsyncTask<Void, Void, DemoModeAvailability>() {
+      @Override protected DemoModeAvailability doInBackground(Void... params) {
+        DemoModeInitializer.GrantPermissionResult grantBroadcastPermissionResult =
+            demoModeInitializer.grantBroadcastPermission();
+        if (grantBroadcastPermissionResult == FAILURE) {
+          return DemoModeAvailability.NEEDS_ROOT_ACCESS;
+        }
+        if (grantBroadcastPermissionResult != SUCCESS) {
+          return DemoModeAvailability.UNAVAILABLE;
+        }
+        DemoModeInitializer.GrantPermissionResult setDemoModeSettingResult =
+            demoModeInitializer.setDemoModeSetting(ENABLED);
+        if (setDemoModeSettingResult != SUCCESS) {
+          return DemoModeAvailability.NEEDS_DEMO_MODE_SETTING;
+        }
+        return DemoModeAvailability.AVAILABLE;
+      }
+
+      @Override protected void onPostExecute(DemoModeAvailability demoModeAvailability) {
+        switch (demoModeAvailability) {
+          case AVAILABLE:
+            callback.show();
+            break;
+          case UNAVAILABLE:
+            callback.hide();
+            break;
+          case NEEDS_ROOT_ACCESS:
+            callback.hide();
+            Toast.makeText(activity, R.string.root_permission_denied, LENGTH_SHORT).show();
+            break;
+          case NEEDS_DEMO_MODE_SETTING:
+            callback.hide();
+            Toast.makeText(activity, R.string.enable_demo_mode_in_settings, LENGTH_SHORT).show();
+            activity.startActivityForResult(demoModeInitializer.demoModeScreenIntent(),
+                REQUEST_CODE_ENABLE_DEMO_MODE);
+            break;
+        }
+      }
+    }.execute();
+  }
+
+  @TargetApi(M) static boolean handleActivityResult(Activity activity, int requestCode,
+      ShowDemoModeSetting callback) {
+    if (requestCode != REQUEST_CODE_ENABLE_DEMO_MODE) {
+      return false;
+    }
+    if (DemoMode.initializer(activity).getDemoModeSetting() == ENABLED) {
+      showDemoModeSetting(activity, callback);
+    }
+    return true;
+  }
+}

--- a/telecine/src/main/java/com/jakewharton/telecine/OverlayView.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/OverlayView.java
@@ -67,6 +67,12 @@ final class OverlayView extends FrameLayout {
     void onCancel();
 
     /**
+     * Called when start is clicked and the view is animating itself out,
+     * before {@link #onStart()}.
+     */
+    void onPrepare();
+
+    /**
      * Called when start is clicked and it is appropriate to start recording. This view will hide
      * itself completely before invoking this callback.
      */
@@ -175,6 +181,7 @@ final class OverlayView extends FrameLayout {
   }
 
   private void countdownComplete() {
+    listener.onPrepare();
     recordingView.animate()
         .alpha(0)
         .setDuration(COUNTDOWN_DELAY)

--- a/telecine/src/main/java/com/jakewharton/telecine/RecordingSession.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/RecordingSession.java
@@ -59,6 +59,9 @@ final class RecordingSession {
   private static final String MIME_TYPE = "video/mp4";
 
   interface Listener {
+    /** Invoked before {@link #onStart()} to prepare UI before recording. */
+    void onPrepare();
+
     /** Invoked immediately prior to the start of recording. */
     void onStart();
 
@@ -121,6 +124,10 @@ final class RecordingSession {
     OverlayView.Listener overlayListener = new OverlayView.Listener() {
       @Override public void onCancel() {
         cancelOverlay();
+      }
+
+      @Override public void onPrepare() {
+        listener.onPrepare();
       }
 
       @Override public void onStart() {

--- a/telecine/src/main/java/com/jakewharton/telecine/TelecineModule.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/TelecineModule.java
@@ -19,6 +19,7 @@ final class TelecineModule {
   private static final boolean DEFAULT_SHOW_COUNTDOWN = true;
   private static final boolean DEFAULT_HIDE_FROM_RECENTS = false;
   private static final boolean DEFAULT_SHOW_TOUCHES = false;
+  private static final boolean DEFAULT_USE_DEMO_MODE = false;
   private static final boolean DEFAULT_RECORDING_NOTIFICATION = false;
   private static final int DEFAULT_VIDEO_SIZE_PERCENTAGE = 100;
 
@@ -81,6 +82,15 @@ final class TelecineModule {
   }
 
   @Provides @ShowTouches static Boolean provideShowTouches(@ShowTouches BooleanPreference pref) {
+    return pref.get();
+  }
+
+  @Provides @Singleton @UseDemoMode static BooleanPreference provideUseDemoModePreference(
+      SharedPreferences prefs) {
+    return new BooleanPreference(prefs, "use-demo-mode", DEFAULT_USE_DEMO_MODE);
+  }
+
+  @Provides @UseDemoMode static Boolean provideUseDemoMode(@UseDemoMode BooleanPreference pref) {
     return pref.get();
   }
 

--- a/telecine/src/main/java/com/jakewharton/telecine/UseDemoMode.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/UseDemoMode.java
@@ -1,0 +1,11 @@
+package com.jakewharton.telecine;
+
+import java.lang.annotation.Retention;
+import javax.inject.Qualifier;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Qualifier
+@Retention(RUNTIME)
+@interface UseDemoMode {
+}

--- a/telecine/src/main/res/layout/activity_main.xml
+++ b/telecine/src/main/res/layout/activity_main.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <FrameLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -126,6 +125,28 @@
             />
         <Switch
             android:id="@+id/switch_show_touches"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            />
+      </LinearLayout>
+
+      <LinearLayout
+          android:id="@+id/container_use_demo_mode"
+          android:layout_width="match_parent"
+          android:layout_height="@dimen/preference_height"
+          android:gravity="center_vertical"
+          android:orientation="horizontal"
+          android:visibility="gone"
+          >
+        <TextView
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:text="@string/use_demo_mode"
+            android:textAlignment="viewStart"
+            />
+        <Switch
+            android:id="@+id/switch_use_demo_mode"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             />

--- a/telecine/src/main/res/values/strings.xml
+++ b/telecine/src/main/res/values/strings.xml
@@ -24,6 +24,9 @@
   <string name="notification_recording_subtitle">Touch the clock area to stop recording.</string>
   <string name="recording_notification">Recording Notification</string>
   <string name="show_touches">Show Touches</string>
+  <string name="use_demo_mode">Use Demo Mode</string>
+  <string name="root_permission_denied">Allow root access to use Demo Mode</string>
+  <string name="enable_demo_mode_in_settings">Enable Demo Mode in Settings</string>
 
   <array name="countdown">
     <item>@string/countdown_three</item>


### PR DESCRIPTION
The option to enable Demo Mode will only be visible after the app is
granted the DUMP permission. The permission can be granted via pm.

There is a split second display delay before the SystemUI updates from the broadcast.
Maybe there's a better spot to send the broadcasts before `RecordingSession.Listener.onStart()`?

Also, of course, just close this if there's not a large use case relative to the code addition. :)