### PR TITLE
Detect if "Draw over other apps" permission is missing and fixes it

### DIFF
--- a/telecine/src/main/java/com/jakewharton/telecine/DrawOverlayHelper.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/DrawOverlayHelper.java
@@ -1,0 +1,40 @@
+package com.jakewharton.telecine;
+
+import android.annotation.TargetApi;
+import android.app.Activity;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.Settings;
+
+import static android.os.Build.VERSION_CODES.M;
+
+final class DrawOverlayHelper {
+
+    private static final int REQUEST_CODE_DRAW_OVERLAY_PERMISSION = 2424;
+
+    private DrawOverlayHelper() {
+        throw new AssertionError("No instances.");
+    }
+
+    static boolean hasPermission(Context context) {
+        return Build.VERSION.SDK_INT < Build.VERSION_CODES.M || Settings.canDrawOverlays(context);
+    }
+
+    @TargetApi(M) static void requestPermission(Activity activity) {
+        Intent intent = new Intent(Settings.ACTION_MANAGE_OVERLAY_PERMISSION);
+        intent.setData(Uri.parse("package:" + activity.getPackageName()));
+        activity.startActivityForResult(intent, REQUEST_CODE_DRAW_OVERLAY_PERMISSION);
+    }
+
+    static boolean handleActivityResult(Activity activity, int requestCode, Analytics analytics) {
+        if (requestCode != REQUEST_CODE_DRAW_OVERLAY_PERMISSION) {
+            return false;
+        }
+        if (hasPermission(activity)) {
+            CaptureHelper.fireScreenCaptureIntent(activity, analytics);
+        }
+        return false;
+    }
+}

--- a/telecine/src/main/java/com/jakewharton/telecine/TelecineActivity.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/TelecineActivity.java
@@ -107,6 +107,10 @@ public final class TelecineActivity extends AppCompatActivity {
   }
 
   @OnClick(R.id.launch) void onLaunchClicked() {
+    if (!DrawOverlayHelper.hasPermission(this)) {
+      DrawOverlayHelper.requestPermission(this);
+      return;
+    }
     Timber.d("Attempting to acquire permission to screen capture.");
     CaptureHelper.fireScreenCaptureIntent(this, analytics);
   }
@@ -204,7 +208,8 @@ public final class TelecineActivity extends AppCompatActivity {
 
   @Override protected void onActivityResult(int requestCode, int resultCode, Intent data) {
     if (!CaptureHelper.handleActivityResult(this, requestCode, resultCode, data, analytics)
-        && !DemoModeHelper.handleActivityResult(this, requestCode, showDemoModeSetting)) {
+        && !DemoModeHelper.handleActivityResult(this, requestCode, showDemoModeSetting)
+            && !DrawOverlayHelper.handleActivityResult(this, requestCode, analytics)) {
       super.onActivityResult(requestCode, resultCode, data);
     }
   }

--- a/telecine/src/main/java/com/jakewharton/telecine/TelecineShortcutLaunchActivity.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/TelecineShortcutLaunchActivity.java
@@ -22,6 +22,11 @@ public final class TelecineShortcutLaunchActivity extends Activity {
     super.onCreate(savedInstanceState);
     ((TelecineApplication) getApplication()).injector().inject(this);
 
+    if (!DrawOverlayHelper.hasPermission(this)) {
+      DrawOverlayHelper.requestPermission(this);
+      return;
+    }
+
     String launchAction = getIntent().getStringExtra(KEY_ACTION);
     if (launchAction == null) {
       launchAction = Analytics.ACTION_SHORTCUT_LAUNCHED;
@@ -36,7 +41,8 @@ public final class TelecineShortcutLaunchActivity extends Activity {
   }
 
   @Override protected void onActivityResult(int requestCode, int resultCode, Intent data) {
-    if (!CaptureHelper.handleActivityResult(this, requestCode, resultCode, data, analytics)) {
+    if (!CaptureHelper.handleActivityResult(this, requestCode, resultCode, data, analytics)
+            && !DrawOverlayHelper.handleActivityResult(this, requestCode, analytics)) {
       super.onActivityResult(requestCode, resultCode, data);
     }
     finish();


### PR DESCRIPTION
This permission should be granted automatically when installed from the Play Store.
But some privacy related apps can automatically disable this permission.
The fix consists in asking the System settings if the app is allowed to "draw over others".
If the permission is not allowed, the user is redirect to the corresponding settings screen.
This also fixes #147