### PR TITLE
Move OverlayView to below the status bar on Oreo+

### DIFF
--- a/telecine/src/main/java/com/jakewharton/telecine/OverlayView.java
+++ b/telecine/src/main/java/com/jakewharton/telecine/OverlayView.java
@@ -4,6 +4,8 @@ import android.animation.Animator;
 import android.animation.AnimatorListenerAdapter;
 import android.annotation.SuppressLint;
 import android.content.Context;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import android.support.annotation.NonNull;
 import android.view.Gravity;
 import android.view.View;
@@ -115,6 +117,13 @@ final class OverlayView extends FrameLayout {
   @Override public WindowInsets onApplyWindowInsets(WindowInsets insets) {
     ViewGroup.LayoutParams lp = getLayoutParams();
     lp.height = insets.getSystemWindowInsetTop();
+
+    boolean canReceiveTouchEventsUnderStatusBar = VERSION.SDK_INT < VERSION_CODES.O;
+    if (!canReceiveTouchEventsUnderStatusBar) {
+      int statusBarHeight = insets.getSystemWindowInsetTop();
+      lp.height += statusBarHeight;
+      setPaddingRelative(getPaddingStart(), getPaddingTop() + statusBarHeight, getPaddingEnd(), getPaddingBottom());
+    }
 
     listener.onResize();
 


### PR DESCRIPTION
![telecine - oreo 2](https://user-images.githubusercontent.com/2387680/30430363-9de56f76-9978-11e7-9837-1016b3af035e.png)

![telecine - oreo 1](https://user-images.githubusercontent.com/2387680/30430296-66b7c026-9978-11e7-836b-411242ba4c82.png)

This PR moves the overlay below the status bar by applying a top-padding to the View's content.

I initially wanted to do this by modifying the `WindowManager.LayoutParams#y` value in `onApplyWindowInsets()` instead, but that triggers a second `onApplyMethodInsets()` call with a different value for `WindowInsets#getSystemWindowInsetTop()` and I am not sure how to avoid/deal with that.

Fixes #149.